### PR TITLE
feat(ci): drop Node.js v10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "10 || 12 || 14 || >=16"
+    "node": "12 || 14 || >=16"
   },
   "scripts": {
     "type-check": "tsc",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is no longer supported.